### PR TITLE
Deactivate headerbar using gsettings to remove it definitely

### DIFF
--- a/guillotine.sh
+++ b/guillotine.sh
@@ -8,3 +8,5 @@ wget \
     https://raw.githubusercontent.com/safesintesi/terminal-guillotine/main/gtk.css \
     -qO- >> $tmpdir/gtk.css
 
+# Remove all headerbar traces
+gsettings set org.gnome.Terminal.Legacy.Settings headerbar false


### PR DESCRIPTION
Hi! Using terminal-guillotine I normally have the following result:
![Screenshot From 2025-05-01 23-21-43](https://github.com/user-attachments/assets/a5d176e8-cd61-47f6-a073-a3e7b4c19dc2)
As you can see some remaining parts of the headerbar are still visible, so this PR adds a small gsettings command to remove it completely.