### PR TITLE
fix: hide ghost boder of some buttons

### DIFF
--- a/gtk.css
+++ b/gtk.css
@@ -7,6 +7,7 @@ terminal-window .titlebar
   background-image:none;
   background-color:transparent;
   margin-top:-100px;
+  border:none;
 }
 
 /* remove rounded corners */


### PR DESCRIPTION
In some distros the headerbar would still show the border of removed buttons.
Set border to none to fix it.
First mentioned in #1 